### PR TITLE
Feature to show thumbs depending upon user preferences and to display image urls having query parameters

### DIFF
--- a/usr/lib/jargonaut/jargonaut.py
+++ b/usr/lib/jargonaut/jargonaut.py
@@ -542,6 +542,14 @@ class App(Gtk.Application):
 
         self.webview.load_html(html, "file:///usr/share/jargonaut/")
 
+    def is_image_url(url):
+        image = url.split('/')[:-1]
+        image = image.split('?')[0]
+        if image.lower().endswith(('.png', '.jpg', '.jpeg', '.gif', '.svg', '.bmp', '.webp')):
+            return True
+        else:
+            return False
+
     @idle
     def print_message(self, nick, text):
         # Escape any tags, i.e. show exactly what people typed, don't let Webkit interpret it.
@@ -556,7 +564,7 @@ class App(Gtk.Application):
         url_pattern = r'((http[s]?://[^\s]{3,}\.[^\s]{2,}))'
         def repl(match):
             url = match.group(1)
-            if url.lower().endswith(('.png', '.jpg', '.jpeg', '.gif', '.svg', '.bmp', '.webp')) and self.show_thumbs:
+            if self.is_image_url(url) and self.show_thumbs:
                 return f'<a href="{url}"><img class="thumb" src="{url}" title="{url}"/></a>'
             else:
                 return f'<a href="{url}">{url}</a>'

--- a/usr/lib/jargonaut/jargonaut.py
+++ b/usr/lib/jargonaut/jargonaut.py
@@ -678,10 +678,7 @@ class App(Gtk.Application):
         self.show_restart_infobar()
 
     def update_show_thumbs(self, active):
-        if active:
-            self.show_thumbs = True
-        else:
-            self.show_thumbs = False
+            self.show_thumbs = True if active else False
 
     @idle
     def update_dark_mode(self, active):

--- a/usr/lib/jargonaut/jargonaut.py
+++ b/usr/lib/jargonaut/jargonaut.py
@@ -547,8 +547,6 @@ class App(Gtk.Application):
         image = image.split('?')[0]
         if image.lower().endswith(('.png', '.jpg', '.jpeg', '.gif', '.svg', '.bmp', '.webp')):
             return True
-        else:
-            return False
 
     @idle
     def print_message(self, nick, text):

--- a/usr/lib/jargonaut/jargonaut.py
+++ b/usr/lib/jargonaut/jargonaut.py
@@ -543,7 +543,7 @@ class App(Gtk.Application):
         self.webview.load_html(html, "file:///usr/share/jargonaut/")
 
     def is_image_url(self,url):
-        image = url.split('/')[:-1]
+        image = url.split('/')[-1]
         image = image.split('?')[0]
         if image.lower().endswith(('.png', '.jpg', '.jpeg', '.gif', '.svg', '.bmp', '.webp')):
             return True

--- a/usr/lib/jargonaut/jargonaut.py
+++ b/usr/lib/jargonaut/jargonaut.py
@@ -542,7 +542,7 @@ class App(Gtk.Application):
 
         self.webview.load_html(html, "file:///usr/share/jargonaut/")
 
-    def is_image_url(url):
+    def is_image_url(self,url):
         image = url.split('/')[:-1]
         image = image.split('?')[0]
         if image.lower().endswith(('.png', '.jpg', '.jpeg', '.gif', '.svg', '.bmp', '.webp')):

--- a/usr/lib/jargonaut/jargonaut.py
+++ b/usr/lib/jargonaut/jargonaut.py
@@ -64,6 +64,7 @@ class App(Gtk.Application):
         self.server = self.settings.get_string("server")
         self.port = self.settings.get_int("port")
         self.tls = self.settings.get_boolean("tls-connection")
+        self.show_thumbs = self.settings.get_boolean("show-thumbs")
         self.nickname = self.get_new_nickname()
 
         self.channel_users = {}
@@ -124,6 +125,7 @@ class App(Gtk.Application):
         bind_entry_widget(self.builder.get_object("pref_password"), self.settings, "password")
         bind_switch_widget(self.builder.get_object("pref_dark"), self.settings, "prefer-dark-mode", fn_callback=self.update_dark_mode)
         bind_switch_widget(self.builder.get_object("pref_acceleration"), self.settings, "hw-acceleration", fn_callback=self.update_hw_acceleration)
+        bind_switch_widget(self.builder.get_object("show_thumbs"), self.settings, "show-thumbs", fn_callback=self.update_show_thumbs)
 
         self.webview = WebKit2.WebView()
         self.update_hw_acceleration(self.settings.get_boolean("hw-acceleration"))
@@ -498,7 +500,7 @@ class App(Gtk.Application):
         url_pattern = r'((http[s]?://[^\s]{3,}\.[^\s]{2,}))'
         def repl(match):
             url = match.group(1)
-            if url.lower().endswith(('.png', '.jpg', '.jpeg', '.gif', '.svg', '.bmp', '.webp')):
+            if url.lower().endswith(('.png', '.jpg', '.jpeg', '.gif', '.svg', '.bmp', '.webp')) and self.show_thumbs:
                 return f'<a href="{url}"><img class="thumb" src="{url}" title="{url}"/></a>'
             else:
                 return f'<a href="{url}">{url}</a>'
@@ -605,6 +607,12 @@ class App(Gtk.Application):
         else:
             policy = WebKit2.HardwareAccelerationPolicy.NEVER
         settings.set_hardware_acceleration_policy(policy)
+
+    def update_show_thumbs(self, active):
+        if active:
+            self.show_thumbs = True
+        else:
+            self.show_thumbs = False
 
     @idle
     def update_dark_mode(self, active):

--- a/usr/share/glib-2.0/schemas/org.x.jargonaut.gschema.xml
+++ b/usr/share/glib-2.0/schemas/org.x.jargonaut.gschema.xml
@@ -33,5 +33,9 @@
       <default>false</default>
       <summary>WebKit2 HW Acceleration</summary>
     </key>
+    <key name="show-thumbs" type="b">
+      <default>false</default>
+      <summary>Whether to show thumbnails or not</summary>
+    </key>
   </schema>
 </schemalist>

--- a/usr/share/glib-2.0/schemas/org.x.jargonaut.gschema.xml
+++ b/usr/share/glib-2.0/schemas/org.x.jargonaut.gschema.xml
@@ -36,5 +36,9 @@
     <key name="timestamp-24h" type="b">
       <default>true</default>
     </key>
+    <key name="show-thumbs" type="b">
+      <default>false</default>
+      <summary>Whether to show thumbnails or not</summary>
+    </key>
   </schema>
 </schemalist>

--- a/usr/share/jargonaut/jargonaut.ui
+++ b/usr/share/jargonaut/jargonaut.ui
@@ -579,6 +579,33 @@
                       </packing>
                     </child>
                     <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="valign">center</property>
+                        <property name="label" translatable="yes">Show Thumbnails</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">6</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSwitch" id="show_thumbs">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="halign">start</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">6</property>
+                      </packing>
+                    </child>
+                    <child>
                       <placeholder/>
                     </child>
                     <child>

--- a/usr/share/jargonaut/jargonaut.ui
+++ b/usr/share/jargonaut/jargonaut.ui
@@ -634,6 +634,33 @@
                       </packing>
                     </child>
                     <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="valign">center</property>
+                        <property name="label" translatable="yes">Show Thumbnails</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">7</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSwitch" id="show_thumbs">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="halign">start</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">7</property>
+                      </packing>
+                    </child>
+                    <child>
                       <placeholder/>
                     </child>
                     <child>


### PR DESCRIPTION
This pr brings a toggle switch under preferences to set whether thumbnails should be shown or not.
By the default, thumbnails are disabled.
This pr also fixes an issue of image urls having query parameters not being show in the chat