### PR TITLE
Add meson build-dependecy and python3-setproctitle depends for Debian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,8 @@ Priority: optional
 Maintainer: Linux Mint <root@linuxmint.com>
 Build-Depends:
     debhelper (>= 9),
-    dh-python
+    dh-python,
+    meson
 Standards-Version: 3.9.5
 
 Package: jargonaut

--- a/debian/control
+++ b/debian/control
@@ -18,6 +18,7 @@ Depends:
     gir1.2-webkit2-4.1 | gir1.2-webkit2-4.0,
     gir1.2-gspell-1,
     python3-irc,
+    python3-setproctitle,
     ${misc:Depends},
     ${python3:Depends}
 Description: Chat Room application


### PR DESCRIPTION
Error message when building without meson installed:
Can't exec "meson": No such file or directory at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 524.