### PR TITLE
Updated build to ensure files are installed where they mean to be.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,4 +10,5 @@ datadir = get_option('datadir')
 podir = meson.source_root() / 'po'
 
 subdir('data')
+subdir('usr')
 subdir('po')

--- a/usr/meson.build
+++ b/usr/meson.build
@@ -1,0 +1,8 @@
+# Install the main script
+install_data('bin/jargonaut', install_dir: prefix / 'bin', install_mode: 'rwxr-xr-x')
+
+# Install the Python library
+install_subdir('lib/jargonaut', install_dir: prefix / 'lib')
+
+# Install shared data
+install_subdir('share', install_dir: prefix / 'share', strip_directory: true)


### PR DESCRIPTION
This ensure the build process is **distro-agnostic** and allow other to build its without needing of `install -D` or other hacks.

the changes are:

* Adding a meson.build inside `usr` and populate it
* use of `strip_directory` to prevent duplication of directory inside `usr` (prevent a `usr/share/share/app` case)
* add `usr` to `subdirs` for the main `meson.build`